### PR TITLE
Inner section merging and special method option

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,22 +155,35 @@ Utilize a built-in style by specifying any of the following names (as a string),
 
 - `"numpy"`: [NumPy-styled docstrings](https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt#docstring-standard) 
         from the parent and child are merged gracefully with nice formatting. The child's docstring sections take precedence 
-	in the case of overlap. 
+	in the case of overlap.
+
+- `"numpy_with_merge"`: Behaves identically to the "numpy" style, but also merges sections that overlap,
+    instead of only keeping the child's section. All sections are concerned except sections "Short Summary",
+    "Extended Summary", "Deprecation Warning" and "Examples" for which the "numpy" style behaviour applies.
 
 - `"google"`: Google-styled docstrings from the parent and child are merged gracefully
 	with nice formatting. The child's docstring sections take precedence in the case of overlap.
 	This adheres to the [napoleon specification for the Google style](http://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google-style-python-docstrings).
 
+- `"google_with_merge"`: Behaves identically to the "google" style, but also merges sections that overlap,
+    instead of only keeping the child's section. All sections are concerned except sections "Short Summary",
+    "Example" and "Examples" (or coresponding aliases) for which the 'google' style applies.
+
 - `"numpy_napoleon"`: NumPy-styled docstrings from the parent and child are merged gracefully
 	with nice formatting. The child's docstring sections take precedence in the case of overlap.
 	This adheres to the [napoleon specification for the NumPy style](http://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html#example-numpy).
+
+- `"numpy_napoleon_with_merge"`: Behaves identically to the 'numpy_napoleon' style, but also merges sections
+    that overlap, instead of only keeping the child's section. All sections are concerned except sections
+    "Short Summary", "Example" and "Examples" (or coresponding aliases) for which the 'numpy_napoleon' style
+    behaviour applies.
 
 - `"reST"`: reST-styled docstrings from the parent and child are merged gracefully
 	with nice formatting. Docstring sections are specified by 
 	[reST section titles](http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#sections).
 	The child's docstring sections take precedence in the case of overlap.
 
-For the `numpy`, `numpy_napoleon`, and `google` styles, if the parent's docstring contains a "Raises" section and the child's docstring implements a "Returns" or a "Yields" section instead, then the "Raises" section is not included in the resulting docstring. This is to accomodate for the relatively common use case in which an abstract method/property raises `NotImplementedError`. Child classes that implement this method/property clearly will not raise this. Of course, any "Raises" section that is explicitly included in the child's docstring will appear in the resulting docstring.
+For the `numpy`, `numpy_with_merge`, `numpy_napoleon`, `numpy_napoleon_with_merge`, `google` and `google_with_merge` styles, if the parent's docstring contains a "Raises" section and the child's docstring implements a "Returns" or a "Yields" section instead, then the "Raises" section is not included in the resulting docstring. This is to accomodate for the relatively common use case in which an abstract method/property raises `NotImplementedError`. Child classes that implement this method/property clearly will not raise this. Of course, any "Raises" section that is explicitly included in the child's docstring will appear in the resulting docstring.
 
 Detailed documentation and example cases for the default styles can be found [here](https://github.com/meowklaski/custom_inherit/blob/master/custom_inherit/_style_store.py)
 

--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ class Parent(metaclass=DocInheritMeta(style="numpy")):
            ----------
            x: int
               blah-x
-              
+
            y: Optional[int]
               blah-y
-           
+
            Raises
            ------
            NotImplementedError"""
@@ -85,7 +85,7 @@ Because we specified `style="numpy"` in `DocInheritMeta`, the inherited docstrin
       ----------
       x: int
          blah-x
-         
+
       y: Optional[int]
          blah-y
 
@@ -146,6 +146,18 @@ class Parent(metaclass=DocInheritMeta(style="numpy", abstract_base_class=True)):
 
 For the "numpy", "google", and "napoleon_numpy" inheritance styles, one then only needs to specify the "Returns" or "Yields" section in the derived class' attribute docstring for it to have a fully-detailed docstring.
 
+Another option is to be able to decide whether to include all special methods, meaning methods that start and
+end by "__" such as "__init__" method, or not in the doctstring inheritance process. Such an option can be pass
+to the `DocInheritMeta` metaclass constructor:
+
+```python
+# Each child class will also merge the special methods' docstring of its parent class
+class Parent(metaclass=DocInheritMeta(style="numpy", include_special_methods=True)):
+   ...
+```
+
+Special methods are not included by default.
+
 ## Built-in Styles
 
 Utilize a built-in style by specifying any of the following names (as a string), wherever the `style` parameter is to be specified. The built-in styles are:
@@ -153,8 +165,8 @@ Utilize a built-in style by specifying any of the following names (as a string),
 - `"parent"`: Wherever the docstring for a child-class' attribute (or for the class itself) is
 	`None`, inherit the corresponding docstring from the parent. (Deprecated in Python 3.5)
 
-- `"numpy"`: [NumPy-styled docstrings](https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt#docstring-standard) 
-        from the parent and child are merged gracefully with nice formatting. The child's docstring sections take precedence 
+- `"numpy"`: [NumPy-styled docstrings](https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt#docstring-standard)
+        from the parent and child are merged gracefully with nice formatting. The child's docstring sections take precedence
 	in the case of overlap.
 
 - `"numpy_with_merge"`: Behaves identically to the "numpy" style, but also merges sections that overlap,
@@ -179,7 +191,7 @@ Utilize a built-in style by specifying any of the following names (as a string),
     behaviour applies.
 
 - `"reST"`: reST-styled docstrings from the parent and child are merged gracefully
-	with nice formatting. Docstring sections are specified by 
+	with nice formatting. Docstring sections are specified by
 	[reST section titles](http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#sections).
 	The child's docstring sections take precedence in the case of overlap.
 
@@ -188,15 +200,15 @@ For the `numpy`, `numpy_with_merge`, `numpy_napoleon`, `numpy_napoleon_with_merg
 Detailed documentation and example cases for the default styles can be found [here](https://github.com/meowklaski/custom_inherit/blob/master/custom_inherit/_style_store.py)
 
 ## Making New Inheritance Styles
-Implementing your inheritance style is simple. 
+Implementing your inheritance style is simple.
 
 - Provide an inheritance style on the fly wherever a style parameter is specified:
     - Supply any function of the form: `func(prnt_doc: str, child_doc: str) -> str`
 
 - Log an inheritance style, and refer to it by name wherever a style parameter is specified, using either:
-    - `custom_inherit.store["my_style"] = func` 
-    - `custom_inherit.add_style("my_style", func)`. 
-    
+    - `custom_inherit.store["my_style"] = func`
+    - `custom_inherit.add_style("my_style", func)`.
+
 ## Installation and Getting Started
 Install via pip:
 
@@ -206,7 +218,7 @@ Install via pip:
 Install via conda:
 
 ```
-    conda install -c conda-forge custom-inherit 
+    conda install -c conda-forge custom-inherit
 ```
 
 or
@@ -264,7 +276,7 @@ custom_inherit.doc_inherit(parent, style="parent"):
         Parameters
         ----------
         parent : Union[str, Any]
-            The object whose docstring, is utilized as the parent docstring 
+            The object whose docstring, is utilized as the parent docstring
 	    during the docstring merge. Or, a string can be provided directly.
 
         style : Union[Hashable, Callable[[str, str], str]], optional (default: "parent")

--- a/src/custom_inherit/__init__.py
+++ b/src/custom_inherit/__init__.py
@@ -4,7 +4,11 @@ from abc import ABCMeta as _ABCMeta
 
 from ._decorator_base import DocInheritDecorator as _DocInheritDecorator
 from ._metaclass_base import DocInheritorBase as _DocInheritorBase
-from ._style_store import google, numpy, numpy_napoleon, parent, reST
+from . import _style_store
+from ._style_store import (
+    google, numpy, numpy_napoleon, parent, reST,
+    google_with_merge, numpy_napoleon_with_merge, numpy_with_merge
+)
 from ._version import get_versions
 
 __version__ = get_versions()["version"]
@@ -112,7 +116,6 @@ class _Store(object):
     def items(self):
         """ D.items() -> a set-like object providing a view on D's items"""
         return self._store.items()
-
 
 store = _Store([(key, getattr(_style_store, key)) for key in _style_store.__all__])
 

--- a/src/custom_inherit/__init__.py
+++ b/src/custom_inherit/__init__.py
@@ -143,7 +143,7 @@ def remove_style(style):
         store.pop(style)
 
 
-def DocInheritMeta(style="parent", abstract_base_class=False):
+def DocInheritMeta(style="parent", abstract_base_class=False, include_special_methods=False):
     """ A metaclass that merges the respective docstrings of a parent class and of its child, along with their
     properties, methods (including classmethod, staticmethod, decorated methods).
 
@@ -159,6 +159,10 @@ def DocInheritMeta(style="parent", abstract_base_class=False):
         will be an abstract base class, whose derived classes will inherit docstrings
         using the numpy-style inheritance scheme.
 
+    include_special_methods: bool, optional (defaul: False)
+        Wether special methods of class (i.e. starting en ending with "__") are included in the docstring
+        inheritance process.
+
 
     Returns
     -------
@@ -166,6 +170,7 @@ def DocInheritMeta(style="parent", abstract_base_class=False):
 
     merge_func = store[style]
     metaclass = _DocInheritorBase
+    metaclass.include_special_methods = include_special_methods
     metaclass.class_doc_inherit = staticmethod(merge_func)
     metaclass.attr_doc_inherit = staticmethod(merge_func)
 

--- a/src/custom_inherit/_metaclass_base.py
+++ b/src/custom_inherit/_metaclass_base.py
@@ -21,6 +21,8 @@ class DocInheritorBase(type):
     This merge-style must be implemented via the static methods `class_doc_inherit`
     and `attr_doc_inherit`, which are set within `custom_inherit.DocInheritMeta`."""
 
+    include_special_methods = False
+
     def __new__(mcs, class_name, class_bases, class_dict):
         # inherit class docstring: the docstring is constructed by traversing
         # the mro for the class and merging their docstrings, with each next
@@ -42,8 +44,10 @@ class DocInheritorBase(type):
                 attribute,
                 (FunctionType, MethodType, classmethod, staticmethod, property),
             )
-
-            if (attr.startswith("__") and attr.endswith("__")) or not is_doc_type:
+            if (
+                (attr.startswith("__") and attr.endswith("__") and not mcs.include_special_methods) or
+                not is_doc_type
+            ):
                 continue
 
             is_static_or_class = isinstance(attribute, (staticmethod, classmethod))

--- a/src/custom_inherit/_style_store.py
+++ b/src/custom_inherit/_style_store.py
@@ -27,7 +27,16 @@ from ._doc_parse_tools import (merge_google_napoleon_docs, merge_numpy_docs,
 """
 
 # All built-in styles must be logged in the __all__ field.
-__all__ = ["parent", "numpy", "reST", "google", "numpy_napoleon"]
+__all__ = [
+    "parent",
+    "numpy",
+    "reST",
+    "google",
+    "numpy_napoleon",
+    "google_with_merge",
+    "numpy_napoleon_with_merge",
+    "numpy_with_merge"
+]
 
 
 def parent(prnt_doc, child_doc):
@@ -273,3 +282,227 @@ def google(prnt_doc, child_doc):
                     notes blah blah'''
         """
     return merge_google_napoleon_docs(prnt_doc, child_doc)
+
+
+def google_with_merge(prnt_doc, child_doc):
+    """ Behaves identically to the 'google' style, but also merges sections that
+    overlap, instead of only keeping the child's section. All sections are
+    concerned except sections "Short Summary", "Example" and "Examples" (or
+    coresponding aliases) for which the 'google' style applies.
+
+    Example: - parent's docstring:
+
+            ''' Parent's line
+
+                Args:
+                    x: int
+                        description of x
+                    y: Union[None, int]
+                        description of y
+
+                Raises:
+                    NotImplemented Error
+
+                Example:
+                    >>> parent_func(x=3, y=None)
+                    NotImplementedError:'''
+
+        - child's docstring:
+
+            ''' Child's line
+
+                Args:
+                    z: Union[None, int]
+                        description of z
+
+                Returns:
+                    int
+
+                Example:
+                    >>> child_func(x=3, y=None, z=4)
+                    7
+
+                Notes:
+                    notes blah blah'''
+
+        - docstring that is ultimately inherited:
+
+            ''' Child's line
+
+                Parameters:
+                    x: int
+                        description of x
+                    y: Union[None, int]
+                        description of y
+                    z: Union[None, int]
+                        description of z
+
+                Returns:
+                    int
+
+                Example:
+                    >>> child_func(x=3, y=None, z=4)
+                    7
+
+                Notes:
+                    notes blah blah'''
+    """
+    return merge_google_napoleon_docs(prnt_doc, child_doc, merge_within_sections=True)
+
+
+def numpy_napoleon_with_merge(prnt_doc, child_doc):
+    """
+    Behaves identically to the 'numpy_napoleon' style, but also merges sections
+    that overlap, instead of only keeping the child's section. All sections are
+    concerned except sections "Short Summary", "Example" and "Examples" (or
+    coresponding aliases) for which the 'numpy_napoleon' style behaviour
+    applies.
+
+    Example: - parent's docstring:
+
+            ''' Parent's line
+
+                Keyword Arguments
+                -----------------
+                x: int
+                    description of x
+                y: Union[None, int]
+                    description of y
+
+                Raises
+                ------
+                NotImplemented Error
+
+                Example
+                -------
+                >>> parent_func(x=3, y=None)
+                NotImplementedError:'''
+
+        - child's docstring:
+
+            ''' Child's line
+
+                Keyword Arguments
+                -----------------
+                z: Union[None, int]
+                    description of z
+
+                Returns
+                -------
+                int
+
+                Notes
+                -----
+                notes blah blah
+
+                Example
+                -------
+                >>> child_func(x=3, y=None, z=4)
+                7'''
+
+        - docstring that is ultimately inherited:
+
+            ''' Child's line
+
+                Keyword Arguments
+                -----------------
+                x: int
+                    description of x
+                y: Union[None, int]
+                    description of y
+                z: Union[None, int]
+                    description of z
+
+                Returns
+                -------
+                int
+
+                Notes
+                -----
+                notes blah blah
+
+                Example
+                -------
+                >>> child_func(x=3, y=None, z=4)
+                7'''
+    """
+    return merge_numpy_napoleon_docs(prnt_doc, child_doc, merge_within_sections=True)
+
+
+def numpy_with_merge(prnt_doc, child_doc):
+    """
+    Behaves identically to the 'numpy' style, but also merges sections that
+    overlap, instead of only keeping the child's section. All sections are
+    concerned except sections "Short Summary", "Extended Summary", "Deprecation
+    Warning" and "Examples" for which the 'numpy' style behaviour applies.
+
+    Example:
+        - parent's docstring:
+
+            ''' Parent's line
+
+                Parameters
+                ----------
+                x: int
+                    description of x
+                y: Union[None, int]
+                    description of y
+
+                Raises
+                ------
+                NotImplemented Error
+
+                Example
+                -------
+                >>> parent_func(x=3, y=None)
+                NotImplementedError:'''
+
+        - child's docstring:
+
+            ''' Child's line
+
+                Parameters
+                ----------
+                z: Union[None, int]
+                    description of z
+
+                Returns
+                -------
+                int
+
+                Notes
+                -----
+                notes blah blah
+
+                Example
+                -------
+                >>> child_func(x=3, y=None, z=4)
+                7'''
+
+        - docstring that is ultimately inherited:
+
+            ''' Child's line
+
+                Parameters
+                ----------
+                x: int
+                    description of x
+                y: Union[None, int]
+                    description of y
+                z: Union[None, int]
+                    description of z
+
+                Returns
+                -------
+                int
+
+                Notes
+                -----
+                notes blah blah
+
+                Example
+                -------
+                >>> child_func(x=3, y=None, z=4)
+                7'''
+    """
+    return merge_numpy_docs(prnt_doc, child_doc, merge_within_sections=True)

--- a/tests/default_styles_test.py
+++ b/tests/default_styles_test.py
@@ -128,8 +128,10 @@ def test_reST():
 
 
 def test_numpy_napoleon():
-    def prnt3():
-        """ first line
+    def prnt():
+        """ Parent's short summary
+
+            Parent's extended summary
 
             Attributes
             ----------
@@ -148,12 +150,8 @@ def test_numpy_napoleon():
             parent's section
 
             Parameters
-            ---------
+            ----------
             parent's Parameters
-
-            Extended Summary
-            ----------------
-            extended
 
             Returns
             -------
@@ -180,8 +178,12 @@ def test_numpy_napoleon():
             alias of Yields - parent's"""
         pass
 
-    def child3():
-        """ Args
+    def child():
+        """ Child's short summary
+
+            Child's extended summary
+
+            Args
             ----
             alias for Parameters - child's section
 
@@ -216,20 +218,21 @@ def test_numpy_napoleon():
         pass
 
     out = (
-        "first line\n\nAttributes\n----------\nparams\n    indented\n\nmulti-line\n\nMethods\n-------\n"
-        "parent methods\n\nWarning\n-------\nwarnings\n\nParameters\n----------\n"
-        "alias for Parameters - child's section\n\nOther Parameters\n----------------\nother\n\n"
-        "Keyword Arguments\n-----------------\nalias for Keyword Arguments - child's section\n\nReturns"
-        "\n-------\nreturn\n\nYields\n------\nyield\n\nRaises\n------\nraise\n\nNotes\n-----\nnote\n\nWarns"
-        "\n-----\nwarns\n\nSee Also\n--------\nsee\n\nReferences\n----------\nref\n\nTodo\n----\ntodo\n\n"
-        "Examples\n--------\nexample"
+        "Child's short summary\n\nChild's extended summary\n\nAttributes\n----------\n"
+        "params\n    indented\n\nmulti-line\n\nMethods\n-------\nparent methods\n\nWarning"
+        "\n-------\nwarnings\n\nParameters\n----------\nalias for Parameters - child's section"
+        "\n\nOther Parameters\n----------------\nother\n\nKeyword Arguments\n-----------------"
+        "\nalias for Keyword Arguments - child's section\n\nReturns\n-------\nreturn\n\nYields"
+        "\n------\nyield\n\nRaises\n------\nraise\n\nNotes\n-----\nnote\n\nWarns\n-----\nwarns"
+        "\n\nSee Also\n--------\nsee\n\nReferences\n----------\nref\n\nTodo\n----\ntodo\n\nExamples"
+        "\n--------\nexample"
     )
 
     assert custom_inherit.store["numpy_napoleon"](None, None) is None
     assert custom_inherit.store["numpy_napoleon"]("", "") is None
     assert custom_inherit.store["numpy_napoleon"]("valid", None) == "valid"
     assert custom_inherit.store["numpy_napoleon"](None, "valid") == "valid"
-    assert custom_inherit.store["numpy_napoleon"](prnt3.__doc__, child3.__doc__) == out
+    assert custom_inherit.store["numpy_napoleon"](prnt.__doc__, child.__doc__) == out
 
 
 def test_google_napoleon():
@@ -314,3 +317,287 @@ def test_google_napoleon():
     assert custom_inherit.store["google"]("valid", None) == "valid"
     assert custom_inherit.store["google"](None, "valid") == "valid"
     assert custom_inherit.store["google"](prnt.__doc__, child.__doc__) == out
+
+
+def test_google_with_merge():
+    def prnt():
+        """ first parent's line
+
+            Attributes:
+                params
+                    - indented
+
+                multi-line
+
+            Methods:
+                parent methods
+
+            Keyword Arguments:
+                parent's section
+
+            Parameters:
+                parent's Parameters
+
+            Examples:
+                parents's example
+
+            Extended Summary:
+                extended
+
+            Returns:
+                return
+
+            Other Parameters:
+                other
+
+            See Also:
+                see
+
+            References:
+                ref
+
+            Todo:
+                todo
+
+            Yield:
+                alias of Yields - parent's"""
+        pass
+
+    def child():
+        """ first child's line
+
+            Args:
+                alias for Parameters - child's section
+
+            Keyword Args:
+                alias for Keyword Arguments - child's section
+
+            Yields:
+                yield
+
+            Raises:
+                raise
+
+            Notes:
+                note
+
+            Examples:
+                child's example
+
+            Warns:
+                warns
+
+            Warnings:
+                warnings
+            """
+        pass
+
+    out = (
+        "first child's line\n\nAttributes:\n    params\n        - indented\n\n    "
+        "multi-line\n\nMethods:\n    parent methods\n\nWarning:\n    warnings\n\nParameters:\n    "
+        "parent's Parameters\n    alias for Parameters - child's section\n\nOther Parameters:\n    "
+        "other\n\nKeyword Arguments:\n    parent's section\n    alias for Keyword Arguments - child's section"
+        "\n\nReturns:\n    return\n\nYields:\n    alias of Yields - parent's\n    yield\n\nRaises:\n    "
+        "raise\n\nNotes:\n    note\n\nWarns:\n    warns\n\nSee Also:\n    see\n\nReferences:\n    "
+        "ref\n\nTodo:\n    todo\n\nExamples:\n    child's example"
+    )
+    assert custom_inherit.store["google_with_merge"](None, None) is None
+    assert custom_inherit.store["google_with_merge"]("", "") is None
+    assert custom_inherit.store["google_with_merge"]("valid", None) == "valid"
+    assert custom_inherit.store["google_with_merge"](None, "valid") == "valid"
+    assert custom_inherit.store["google_with_merge"](prnt.__doc__, child.__doc__) == out
+
+
+def test_numpy_with_merge():
+    def prnt():
+        """ first parent's line
+
+            Attributes
+            ----------
+            parent's params
+                indented
+
+            multi-line
+
+            Parameters
+            ----------
+            Parent's param
+
+            Extended Summary
+            ----------------
+            extended
+
+            Returns
+            -------
+            return
+
+            Other Parameters
+            ----------------
+            other
+
+            See Also
+            --------
+            see
+
+            Examples
+            --------
+            Parent's example
+
+            References
+            ----------
+            ref """
+        pass
+
+    def child():
+        """ first child's line
+
+            Deprecation Warning
+            -------------------
+            dep
+
+            Parameters
+            ----------
+            child's params
+
+            Yields
+            ------
+            yield
+
+            Raises
+            ------
+            raise
+
+            Notes
+            -----
+            note
+
+            Examples
+            --------
+            child's example
+            """
+        pass
+
+    numpy_out = (
+        "first child's line\n\nDeprecation Warning\n-------------------\ndep\n\nAttributes\n----------"
+        "\nparent's params\n    indented\n\nmulti-line\n\nExtended Summary\n----------------\nextended\n"
+        "\nParameters\n----------\nParent's param\nchild's params\n\nReturns\n-------\nreturn\n\nYields"
+        "\n------\nyield\n\nOther Parameters\n----------------\nother\n\nRaises\n------\nraise\n\nSee Also"
+        "\n--------\nsee\n\nNotes\n-----\nnote\n\nReferences\n----------\nref\n\nExamples\n--------\n"
+        "child's example"
+    )
+    assert custom_inherit.store["numpy_with_merge"](None, None) is None
+    assert custom_inherit.store["numpy_with_merge"]("", "") is None
+    assert custom_inherit.store["numpy_with_merge"]("valid", None) == "valid"
+    assert custom_inherit.store["numpy_with_merge"](None, "valid") == "valid"
+    assert custom_inherit.store["numpy_with_merge"](prnt.__doc__, child.__doc__) == numpy_out
+
+
+def test_numpy_napoleon_with_merge():
+    def prnt():
+        """ Parent's short summary
+
+            Parent's extended summary
+
+            Attributes
+            ----------
+            params
+                indented
+
+            multi-line
+
+            Methods
+            -------
+            parent methods
+
+
+            Keyword Arguments
+            -----------------
+            parent's section
+
+            Parameters
+            ---------
+            parent's Parameters
+
+            Returns
+            -------
+            return
+
+            Other Parameters
+            ----------------
+            other
+
+            Examples
+            --------
+            parent's example
+
+            See Also
+            --------
+            see
+
+            References
+            ----------
+            ref
+
+            Todo
+            ----
+            todo
+
+            Yield
+            -----
+            alias of Yields - parent's"""
+        pass
+
+    def child():
+        """ Child's short summary
+
+            Child's extended summary
+
+            Args
+            ----
+            alias for Parameters - child's section
+
+            Keyword Args
+            ------------
+            alias for Keyword Arguments - child's section
+
+            Yields
+            ------
+            yield
+
+            Raises
+            ------
+            raise
+
+            Notes
+            -----
+            note
+
+            Examples
+            --------
+            child's example
+
+            Warns
+            -----
+            warns
+
+            Warnings
+            --------
+            warnings
+            """
+        pass
+
+    out = (
+        "Child's short summary\n\nChild's extended summary\n\nAttributes\n----------\nparams\n    "
+        "indented\n\nmulti-line\n\nMethods\n-------\nparent methods\n\nWarning\n-------\nwarnings\n"
+        "\nParameters\n----------\nparent's Parameters\nalias for Parameters - child's section\n"
+        "\nOther Parameters\n----------------\nother\n\nKeyword Arguments\n-----------------\n"
+        "parent's section\nalias for Keyword Arguments - child's section\n\nReturns\n-------\n"
+        "return\n\nYields\n------\nalias of Yields - parent's\nyield\n\nRaises\n------\nraise\n"
+        "\nNotes\n-----\nnote\n\nWarns\n-----\nwarns\n\nSee Also\n--------\nsee\n\nReferences\n"
+        "----------\nref\n\nTodo\n----\ntodo\n\nExamples\n--------\nchild's example"
+    )
+    assert custom_inherit.store["numpy_napoleon_with_merge"](None, None) is None
+    assert custom_inherit.store["numpy_napoleon_with_merge"]("", "") is None
+    assert custom_inherit.store["numpy_napoleon_with_merge"]("valid", None) == "valid"
+    assert custom_inherit.store["numpy_napoleon_with_merge"](None, "valid") == "valid"
+    assert custom_inherit.store["numpy_napoleon_with_merge"](prnt.__doc__, child.__doc__) == out

--- a/tests/metaclass_test.py
+++ b/tests/metaclass_test.py
@@ -52,6 +52,10 @@ class Parent(object):
 
 
 class Kid(Parent):
+    def __init__(self):
+        """kid"""
+        pass
+
     def kid_method(self):
         """kid"""
         pass
@@ -87,6 +91,12 @@ def test_abc():
 def test_sideeffect():
     assert getdoc(Kid.kid_method) == "kid"
     assert signature(Kid.method) == signature(Parent.method)
+
+
+def test_special_method():
+    # by default, Kid.__init__ docstring should not inherit from its parent
+    assert isinstance(Kid().__init__, MethodType)
+    assert getdoc(Kid.__init__) == "kid"
 
 
 def test_method():
@@ -145,6 +155,10 @@ class Parent2(object):
 
 
 class Kid2(Parent2):
+    def __init__(self):
+        """kid"""
+        pass
+
     def kid_method(self):
         """kid"""
         pass
@@ -168,6 +182,12 @@ class Kid2(Parent2):
 def test_sideeffect2():
     assert getdoc(Kid2.kid_method) == "kid"
     assert signature(Kid2.method) == signature(Parent.method)
+
+
+def test_special_method2():
+    # by default, Kid.__init__ docstring should not inherit from its parent
+    assert isinstance(Kid2().__init__, MethodType)
+    assert getdoc(Kid2.__init__) == "kid"
 
 
 def test_method2():
@@ -218,3 +238,22 @@ def test_class_docstring():
         getdoc(Child)
         == "This is mixin which does something.\n\nAttributes\n----------\nbar\n\nReturns\n-------\nfoo"
     )
+
+
+""" Include special method option"""
+
+@add_metaclass(DocInheritMeta(style=style, include_special_methods=True))
+class Parent3(object):
+    def __init__(self):
+        """"""
+        pass
+
+class Kid3(Parent3):
+    def __init__(self):
+        """kid"""
+        pass
+
+def test_special_method3():
+    # __init__ docstring should inherit from Parent3
+    assert isinstance(Kid3().__init__, MethodType)
+    assert getdoc(Kid3.__init__) == "valid"


### PR DESCRIPTION
Hi,

here is my contribution to your nice package, with three new built-in styles allowing to merge inner sections of parent and child, as well as an option to include specials methods like __init__ into the docstring merge process.

It is a answer to issues #25 and #30 

I wrote new tests for those improvements, updated docstrings and the readme file. You can review it (i might have made some syntax mistakes, english is not my native language).

I didn't update the CHANGELOG file nor the version: I let you to do it. 

I also fixed what seems to be a bug in the main __init__.py  and tests you wrote for the numpy_napoleon style which didn't seem to respect the correct syntax (it seems to me that there is no "Extended Summary" section in the napoleon style).

Feel free to make any comment on things you would like me to change. 

Cheers