### PR TITLE
Add Methods to numpydoc doc_sections. Fix #33

### DIFF
--- a/src/custom_inherit/_doc_parse_tools/numpy_parse_tools.py
+++ b/src/custom_inherit/_doc_parse_tools/numpy_parse_tools.py
@@ -23,6 +23,7 @@ def parse_numpy_doc(doc):
             ("Short Summary", None),
             ("Deprecation Warning", None),
             ("Attributes", None),
+            ("Methods", None),
             ("Extended Summary", None),
             ("Parameters", None),
             ("Returns", None),


### PR DESCRIPTION
numpydoc allow for an`Methods` [section](https://numpydoc.readthedocs.io/en/latest/format.html#documenting-classes)
