### PR TITLE
Copy the base metaclass for each new metaclass

### DIFF
--- a/src/custom_inherit/__init__.py
+++ b/src/custom_inherit/__init__.py
@@ -169,7 +169,7 @@ def DocInheritMeta(style="parent", abstract_base_class=False, include_special_me
     custom_inherit.DocInheritorBase"""
 
     merge_func = store[style]
-    metaclass = _DocInheritorBase
+    metaclass = type(_DocInheritorBase.__name__, _DocInheritorBase.__bases__, dict(_DocInheritorBase.__dict__))
     metaclass.include_special_methods = include_special_methods
     metaclass.class_doc_inherit = staticmethod(merge_func)
     metaclass.attr_doc_inherit = staticmethod(merge_func)


### PR DESCRIPTION
In some circumstances, a method attached to the base metaclass is overridden. I was not able to create a standalone reproducer, in my case this happened in a test suite when the tests are ran in a specific order and when some specific imports are done.

This can be fixed by duplicating the base metaclass, so a unique metaclass is created when `DocInheritMeta` is called.