### PR TITLE
Remove intruder args

### DIFF
--- a/src/custom_inherit/__init__.py
+++ b/src/custom_inherit/__init__.py
@@ -30,7 +30,7 @@ __all__ = ["DocInheritMeta", "doc_inherit", "store", "add_style", "remove_style"
 
 
 def _check_style_function(style_func):
-    out = style_func("", "")
+    out = style_func("", lambda x:x)
     if not isinstance(out, _basestring) and out is not None:
         raise TypeError
     return None

--- a/src/custom_inherit/_decorator_base.py
+++ b/src/custom_inherit/_decorator_base.py
@@ -1,3 +1,5 @@
+import inspect
+
 try:
     basestring
 except NameError:
@@ -14,7 +16,7 @@ class DocInheritDecorator(object):
 
     Methods
     -------
-    doc_merger(prnt_attr_doc, child_doc)
+    doc_merger(prnt_attr_doc, child_func)
         Merges the parent and child docstrings into a single docstring.
 
     Notes
@@ -44,18 +46,18 @@ class DocInheritDecorator(object):
         -------
         FunctionType
             The decorated function/method/property whose docstring is given by
-            DocInheritDecorator.doc_merger(prnt_attr_doc, child_doc)"""
-        func.__doc__ = self.doc_merger(self.prnt_doc, func.__doc__)
+            DocInheritDecorator.doc_merger(prnt_attr_doc, child_func)"""
+        func.__doc__ = self.doc_merger(self.prnt_doc, func)
         return func
 
     @staticmethod
-    def doc_merger(prnt_attr_doc, child_doc):
+    def doc_merger(prnt_attr_doc, child_func):
         """Merges the parent and child docstrings into a single docstring.
 
         Parameters
         ----------
         prnt_attr_doc: Union[None, str]
-        child_doc: Union[None, str]
+        child_func: Union[None, FunctionType]
 
         Raises
         ------

--- a/src/custom_inherit/_doc_parse_tools/napoleon_parse_tools.py
+++ b/src/custom_inherit/_doc_parse_tools/napoleon_parse_tools.py
@@ -95,11 +95,13 @@ def parse_napoleon_doc(doc, style):
     return doc_sections
 
 
-def merge_section(key, prnt_sec, child_sec, style, merge_within_sections=False):
+def merge_section(child_func, key, prnt_sec, child_sec, style, merge_within_sections=False):
     """Synthesize a output napoleon docstring section.
 
     Parameters
     ----------
+    child_func: FunctionType
+        The child function which doc is being merged.
     key: str
         The napoleon-section being merged.
     prnt_sec: Optional[str]
@@ -116,6 +118,14 @@ def merge_section(key, prnt_sec, child_sec, style, merge_within_sections=False):
 
     assert style in ("google", "numpy")
 
+    if key in section_items.SECTION_NAMES:
+        body = section_items.merge(child_func, key, prnt_sec, child_sec, merge_within_sections, style)
+    else:
+        body = prnt_sec if child_sec is None else child_sec
+
+    if not body:
+        return None
+
     if key == "Short Summary":
         header = ""
     else:
@@ -124,19 +134,16 @@ def merge_section(key, prnt_sec, child_sec, style, merge_within_sections=False):
         else:
             header = "\n".join((key + ":", ""))
 
-    if key in section_items.SECTION_NAMES:
-        body = section_items.merge(prnt_sec, child_sec, merge_within_sections, style)
-    else:
-        body = prnt_sec if child_sec is None else child_sec
-
     return header + body
 
 
-def merge_all_sections(prnt_sctns, child_sctns, style, merge_within_sections=False):
+def merge_all_sections(child_func, prnt_sctns, child_sctns, style, merge_within_sections=False):
     """Merge the doc-sections of the parent's and child's attribute into a single docstring.
 
     Parameters
     ----------
+    child_func: FunctionType
+        The child function which doc is being merged.
     prnt_sctns: OrderedDict[str, Union[None,str]]
     child_sctns: OrderedDict[str, Union[None,str]]
 
@@ -154,6 +161,7 @@ def merge_all_sections(prnt_sctns, child_sctns, style, merge_within_sections=Fal
 
     for key in prnt_sctns:
         sect = merge_section(
+            child_func,
             key,
             prnt_sctns[key],
             child_sctns[key],
@@ -166,7 +174,7 @@ def merge_all_sections(prnt_sctns, child_sctns, style, merge_within_sections=Fal
 
 
 def merge_numpy_napoleon_docs(
-    prnt_doc=None, child_doc=None, merge_within_sections=False
+    prnt_doc=None, child_func=None, merge_within_sections=False
 ):
     """Merge two numpy-style docstrings into a single docstring, according to napoleon docstring sections.
 
@@ -183,8 +191,8 @@ def merge_numpy_napoleon_docs(
     ----------
     prnt_doc: Optional[str]
         The docstring from the parent.
-    child_doc: Optional[str]
-        The docstring from the child.
+    child_func: Optional[FunctionType]
+        The child function.
 
     Returns
     -------
@@ -192,15 +200,16 @@ def merge_numpy_napoleon_docs(
         The merged docstring."""
     style = "numpy"
     return merge_all_sections(
+        child_func,
         parse_napoleon_doc(prnt_doc, style),
-        parse_napoleon_doc(child_doc, style),
+        parse_napoleon_doc(child_func.__doc__, style),
         style,
         merge_within_sections=merge_within_sections,
     )
 
 
 def merge_google_napoleon_docs(
-    prnt_doc=None, child_doc=None, merge_within_sections=False
+    prnt_doc=None, child_func=None, merge_within_sections=False
 ):
     """Merge two google-style docstrings into a single docstring, according to napoleon docstring sections.
 
@@ -217,15 +226,17 @@ def merge_google_napoleon_docs(
     ----------
     prnt_doc: Optional[str]
         The docstring from the parent.
-    child_doc: Optional[str]
-        The docstring from the child.
+    child_func: Optional[FunctionType]
+        The child function.
 
     Returns
     -------
     Union[str, None]
         The merged docstring."""
     style = "google"
+    child_doc = None if child_func is None else child_func.__doc__
     return merge_all_sections(
+        child_func,
         parse_napoleon_doc(prnt_doc, style),
         parse_napoleon_doc(child_doc, style),
         style,

--- a/src/custom_inherit/_doc_parse_tools/rest_parse_tools.py
+++ b/src/custom_inherit/_doc_parse_tools/rest_parse_tools.py
@@ -72,10 +72,10 @@ def parse_rest_doc(doc):
     return doc_sections
 
 
-def merge_rest_docs(prnt_doc=None, child_doc=None):
+def merge_rest_docs(prnt_doc=None, child_func=None):
     """ See custom_inherit.style_store.reST for details. """
     prnt_sections = parse_rest_doc(prnt_doc)
-    child_sections = parse_rest_doc(child_doc)
+    child_sections = parse_rest_doc(child_func.__doc__)
 
     header = prnt_sections[""]
     prnt_sections.update(child_sections)

--- a/src/custom_inherit/_style_store.py
+++ b/src/custom_inherit/_style_store.py
@@ -43,16 +43,17 @@ __all__ = [
 ]
 
 
-def parent(prnt_doc, child_doc):
+def parent(prnt_doc, child_func):
     """Wherever the docstring for a child-class' attribute (or for the class itself) is
     `None`, inherit the corresponding docstring from the parent.
 
     *NOTE* As of Python 3.5, this is the default behavior of the built-in function
     inspect.getdoc, and thus this style is deprecated Python 3.(>=5)."""
+    child_doc = child_func.__doc__
     return child_doc if child_doc is not None else prnt_doc
 
 
-def numpy(prnt_doc, child_doc):
+def numpy(prnt_doc, child_func):
     """Merges numpy-styled docstrings from the parent and child.
 
     Specifically, any docstring section that appears in the parent's docstring that
@@ -114,10 +115,10 @@ def numpy(prnt_doc, child_doc):
                 Notes
                 -----
                 notes blah blah'''"""
-    return merge_numpy_docs(prnt_doc, child_doc)
+    return merge_numpy_docs(prnt_doc, child_func)
 
 
-def reST(prnt_doc, child_doc):
+def reST(prnt_doc, child_func):
     """Merge two reST-style docstrings into a single docstring.
 
     Given the reST-style docstrings from a parent and child's attributes, merge the docstring
@@ -165,10 +166,10 @@ def reST(prnt_doc, child_doc):
                    ~~~~~~~~~
                    content for NewHeader '''
     """
-    return merge_rest_docs(prnt_doc, child_doc)
+    return merge_rest_docs(prnt_doc, child_func)
 
 
-def numpy_napoleon(prnt_doc, child_doc):
+def numpy_napoleon(prnt_doc, child_func):
     """Behaves identically to the 'numpy' style, but abides by the docstring sections
     specified by the "Napoleon" standard.
 
@@ -222,10 +223,10 @@ def numpy_napoleon(prnt_doc, child_doc):
                 -----
                 notes blah blah'''
     """
-    return merge_numpy_napoleon_docs(prnt_doc, child_doc)
+    return merge_numpy_napoleon_docs(prnt_doc, child_func)
 
 
-def google(prnt_doc, child_doc):
+def google(prnt_doc, child_func):
     """Merges google-styled docstrings from the parent and child, abiding to the docstring sections
     specified by the "Napoleon" standard.
 
@@ -285,10 +286,10 @@ def google(prnt_doc, child_doc):
                 Notes:
                     notes blah blah'''
     """
-    return merge_google_napoleon_docs(prnt_doc, child_doc)
+    return merge_google_napoleon_docs(prnt_doc, child_func)
 
 
-def google_with_merge(prnt_doc, child_doc):
+def google_with_merge(prnt_doc, child_func):
     """Behaves identically to the 'google' style, but also merges sections that
     overlap, instead of only keeping the child's section. All sections are
     concerned except sections "Short Summary", "Example" and "Examples" (or
@@ -351,10 +352,10 @@ def google_with_merge(prnt_doc, child_doc):
                 Notes:
                     notes blah blah'''
     """
-    return merge_google_napoleon_docs(prnt_doc, child_doc, merge_within_sections=True)
+    return merge_google_napoleon_docs(prnt_doc, child_func, merge_within_sections=True)
 
 
-def numpy_napoleon_with_merge(prnt_doc, child_doc):
+def numpy_napoleon_with_merge(prnt_doc, child_func):
     """
     Behaves identically to the 'numpy_napoleon' style, but also merges sections
     that overlap, instead of only keeping the child's section. All sections are
@@ -430,10 +431,10 @@ def numpy_napoleon_with_merge(prnt_doc, child_doc):
                 >>> child_func(x=3, y=None, z=4)
                 7'''
     """
-    return merge_numpy_napoleon_docs(prnt_doc, child_doc, merge_within_sections=True)
+    return merge_numpy_napoleon_docs(prnt_doc, child_func, merge_within_sections=True)
 
 
-def numpy_with_merge(prnt_doc, child_doc):
+def numpy_with_merge(prnt_doc, child_func):
     """
     Behaves identically to the 'numpy' style, but also merges sections that
     overlap, instead of only keeping the child's section. All sections are
@@ -511,4 +512,4 @@ def numpy_with_merge(prnt_doc, child_doc):
                 >>> child_func(x=3, y=None, z=4)
                 7'''
     """
-    return merge_numpy_docs(prnt_doc, child_doc, merge_within_sections=True)
+    return merge_numpy_docs(prnt_doc, child_func, merge_within_sections=True)

--- a/tests/decorator_test.py
+++ b/tests/decorator_test.py
@@ -73,20 +73,25 @@ def test_function():
 
 
 def test_args_filter():
-    def parent(foo):
+    def parent(foo, *parent_args, **parent_kwargs):
         """
         Args:
             foo: bar
+            *parent_args: Parent *args
+            **parent_kwargs: Parent **kwargs
         """
 
     @doc_inherit(parent, style="google_with_merge")
-    def child(x):
+    def child(x, *child_args, **child_kwargs):
         """
         Args:
             x: X
+            child_args: Not *args
+            *child_args: Child *args
+            **child_kwargs: Child **kwargs
         """
 
-    assert child.__doc__ == "Parameters:\n    x: X"
+    assert child.__doc__ == "Parameters:\n    x: X\n    *child_args: Child *args\n    **child_kwargs: Child **kwargs"
 
 def test_method():
     assert isinstance(Kid2().method, MethodType)

--- a/tests/decorator_test.py
+++ b/tests/decorator_test.py
@@ -72,6 +72,22 @@ def test_function():
     assert getdoc(f) == "valid"
 
 
+def test_args_filter():
+    def parent(foo):
+        """
+        Args:
+            foo: bar
+        """
+
+    @doc_inherit(parent, style="google_with_merge")
+    def child(x):
+        """
+        Args:
+            x: X
+        """
+
+    assert child.__doc__ == "Parameters:\n    x: X"
+
 def test_method():
     assert isinstance(Kid2().method, MethodType)
     assert getdoc(Kid2.method) == "valid"

--- a/tests/default_styles_test.py
+++ b/tests/default_styles_test.py
@@ -1,14 +1,16 @@
 import custom_inherit
 
+from custom_inherit._metaclass_base import new_func_with_doc
+
 
 def test_parent():
-    assert custom_inherit.store["parent"]("a", "b") == "b"
+    assert custom_inherit.store["parent"]("a", new_func_with_doc("b")) == "b"
     assert custom_inherit.store["parent"]("a", None) == "a"
     assert custom_inherit.store["parent"](None, None) is None
 
 
 def test_numpy():
-    def prnt():
+    def prnt(params, other):
         """first line
 
         Attributes
@@ -39,7 +41,7 @@ def test_numpy():
         ref"""
         pass
 
-    def child():
+    def child(params):
         """Deprecation Warning
         -------------------
         dep
@@ -69,16 +71,16 @@ def test_numpy():
     numpy_out = (
         "first line\n\nDeprecation Warning\n-------------------\ndep\n\nAttributes\n----------\nparams\n    "
         "indented\n\nmulti-line\n\nExtended Summary\n----------------\nextended\n\nParameters\n----------\n"
-        "params\n\nReturns\n-------\nreturn\n\nYields\n------\nyield\n\nOther Parameters"
-        "\n----------------\nother\n\nRaises\n------\nraise\n\nSee Also\n--------\nsee\n\n"
+        "params\n\nReturns\n-------\nreturn\n\nYields\n------\nyield\n\n"
+        "Raises\n------\nraise\n\nSee Also\n--------\nsee\n\n"
         "Notes\n-----\nnote\n\nReferences\n----------"
         "\nref\n\nExamples\n--------\nexample"
     )
     assert custom_inherit.store["numpy"](None, None) is None
-    assert custom_inherit.store["numpy"]("", "") is None
+    assert custom_inherit.store["numpy"]("", new_func_with_doc("")) is None
     assert custom_inherit.store["numpy"]("valid", None) == "valid"
-    assert custom_inherit.store["numpy"](None, "valid") == "valid"
-    assert custom_inherit.store["numpy"](prnt.__doc__, child.__doc__) == numpy_out
+    assert custom_inherit.store["numpy"](None, new_func_with_doc("valid")) == "valid"
+    assert custom_inherit.store["numpy"](prnt.__doc__, child) == numpy_out
 
 
 def test_reST():
@@ -121,14 +123,14 @@ def test_reST():
     )
 
     assert custom_inherit.store["reST"](None, None) == ""
-    assert custom_inherit.store["reST"]("", "") == ""
+    assert custom_inherit.store["reST"]("", new_func_with_doc("")) == ""
     assert custom_inherit.store["reST"]("valid", None) == "valid"
-    assert custom_inherit.store["reST"](None, "valid") == "valid"
-    assert custom_inherit.store["reST"](prnt2.__doc__, child2.__doc__) == reST_out
+    assert custom_inherit.store["reST"](None, new_func_with_doc("valid")) == "valid"
+    assert custom_inherit.store["reST"](prnt2.__doc__, child2) == reST_out
 
 
 def test_numpy_napoleon():
-    def prnt():
+    def prnt(params, other):
         """Parent's short summary
 
         Parent's extended summary
@@ -151,7 +153,7 @@ def test_numpy_napoleon():
 
         Parameters
         ----------
-        parent's Parameters
+        params: parent's Parameters
 
         Returns
         -------
@@ -178,14 +180,14 @@ def test_numpy_napoleon():
         alias of Yields - parent's"""
         pass
 
-    def child():
+    def child(params):
         """Child's short summary
 
         Child's extended summary
 
         Args
         ----
-        alias for Parameters - child's section
+        params: alias for Parameters - child's section
 
         Keyword Args
         ------------
@@ -220,8 +222,8 @@ def test_numpy_napoleon():
     out = (
         "Child's short summary\n\nChild's extended summary\n\nAttributes\n----------\n"
         "params\n    indented\n\nmulti-line\n\nMethods\n-------\nparent methods\n\nWarning"
-        "\n-------\nwarnings\n\nParameters\n----------\nalias for Parameters - child's section"
-        "\n\nOther Parameters\n----------------\nother\n\nKeyword Arguments\n-----------------"
+        "\n-------\nwarnings\n\nParameters\n----------\nparams: alias for Parameters - child's section"
+        "\n\nKeyword Arguments\n-----------------"
         "\nalias for Keyword Arguments - child's section\n\nReturns\n-------\nreturn\n\nYields"
         "\n------\nyield\n\nRaises\n------\nraise\n\nNotes\n-----\nnote\n\nWarns\n-----\nwarns"
         "\n\nSee Also\n--------\nsee\n\nReferences\n----------\nref\n\nTodo\n----\ntodo\n\nExamples"
@@ -229,10 +231,10 @@ def test_numpy_napoleon():
     )
 
     assert custom_inherit.store["numpy_napoleon"](None, None) is None
-    assert custom_inherit.store["numpy_napoleon"]("", "") is None
+    assert custom_inherit.store["numpy_napoleon"]("", new_func_with_doc("")) is None
     assert custom_inherit.store["numpy_napoleon"]("valid", None) == "valid"
-    assert custom_inherit.store["numpy_napoleon"](None, "valid") == "valid"
-    assert custom_inherit.store["numpy_napoleon"](prnt.__doc__, child.__doc__) == out
+    assert custom_inherit.store["numpy_napoleon"](None, new_func_with_doc("valid")) == "valid"
+    assert custom_inherit.store["numpy_napoleon"](prnt.__doc__, child) == out
 
 
 def test_methods_section_in_numpy():
@@ -240,6 +242,7 @@ def test_methods_section_in_numpy():
 
     from custom_inherit import DocInheritMeta
 
+    # __import__('pudb').set_trace()
     @add_metaclass(metaclass=DocInheritMeta(style="numpy_with_merge"))
     class Parent:
         """Parent summary.
@@ -276,7 +279,7 @@ meth"""
 
 
 def test_google_napoleon():
-    def prnt():
+    def prnt(params, other):
         """first line
 
         Attributes:
@@ -293,7 +296,7 @@ def test_google_napoleon():
             parent's section
 
         Parameters:
-            parent's Parameters
+            params: parent's Parameters
 
         Extended Summary:
             extended
@@ -317,9 +320,10 @@ def test_google_napoleon():
             alias of Yields - parent's"""
         pass
 
-    def child():
-        """Args:
-            alias for Parameters - child's section
+    def child(params):
+        """
+        Args:
+            params: alias for Parameters - child's section
 
         Keyword Args:
             alias for Keyword Arguments - child's section
@@ -346,21 +350,21 @@ def test_google_napoleon():
 
     out = (
         "first line\n\nAttributes:\n    params\n        - indented\n\n    multi-line\n\nMethods:\n    "
-        "parent methods\n\nWarning:\n    warnings\n\nParameters:\n    alias for Parameters - child's "
-        "section\n\nOther Parameters:\n    other\n\nKeyword Arguments:\n    alias for Keyword Arguments - child's "
+        "parent methods\n\nWarning:\n    warnings\n\nParameters:\n    params: alias for Parameters - child's "
+        "section\n\nKeyword Arguments:\n    alias for Keyword Arguments - child's "
         "section\n\nReturns:\n    return\n\nYields:\n    yield\n\nRaises:\n    raise\n\nNotes:\n    note\n\n"
         "Warns:\n    warns\n\nSee Also:\n    see\n\nReferences:\n    ref\n\nTodo:\n    todo\n\nExamples:\n    example"
     )
 
     assert custom_inherit.store["google"](None, None) is None
-    assert custom_inherit.store["google"]("", "") is None
+    assert custom_inherit.store["google"]("", new_func_with_doc("")) is None
     assert custom_inherit.store["google"]("valid", None) == "valid"
-    assert custom_inherit.store["google"](None, "valid") == "valid"
-    assert custom_inherit.store["google"](prnt.__doc__, child.__doc__) == out
+    assert custom_inherit.store["google"](None, new_func_with_doc("valid")) == "valid"
+    assert custom_inherit.store["google"](prnt.__doc__, child) == out
 
 
 def test_google_with_merge():
-    def prnt():
+    def prnt(params, other):
         """first parent's line
 
         Attributes:
@@ -376,7 +380,7 @@ def test_google_with_merge():
             parent's section
 
         Parameters:
-            parent's Parameters
+            params: parent's Parameters
 
         Examples:
             parents's example
@@ -403,11 +407,11 @@ def test_google_with_merge():
             alias of Yields - parent's"""
         pass
 
-    def child():
+    def child(params):
         """first child's line
 
         Args:
-            alias for Parameters - child's section
+            params: alias for Parameters - child's section
 
         Keyword Args:
             alias for Keyword Arguments - child's section
@@ -435,21 +439,21 @@ def test_google_with_merge():
     out = (
         "first child's line\n\nAttributes:\n    params\n        - indented\n\n    "
         "multi-line\n\nMethods:\n    parent methods\n\nWarning:\n    warnings\n\nParameters:\n    "
-        "parent's Parameters\n    alias for Parameters - child's section\n\nOther Parameters:\n    "
-        "other\n\nKeyword Arguments:\n    parent's section\n    alias for Keyword Arguments - child's section"
+        "params: alias for Parameters - child's section"
+        "\n\nKeyword Arguments:\n    parent's section\n    alias for Keyword Arguments - child's section"
         "\n\nReturns:\n    return\n\nYields:\n    yield\n\nRaises:\n    "
         "raise\n\nNotes:\n    note\n\nWarns:\n    warns\n\nSee Also:\n    see\n\nReferences:\n    "
         "ref\n\nTodo:\n    todo\n\nExamples:\n    child's example"
     )
     assert custom_inherit.store["google_with_merge"](None, None) is None
-    assert custom_inherit.store["google_with_merge"]("", "") is None
+    assert custom_inherit.store["google_with_merge"]("", new_func_with_doc("")) is None
     assert custom_inherit.store["google_with_merge"]("valid", None) == "valid"
-    assert custom_inherit.store["google_with_merge"](None, "valid") == "valid"
-    assert custom_inherit.store["google_with_merge"](prnt.__doc__, child.__doc__) == out
+    assert custom_inherit.store["google_with_merge"](None, new_func_with_doc("valid")) == "valid"
+    assert custom_inherit.store["google_with_merge"](prnt.__doc__, child) == out
 
 
 def test_numpy_with_merge():
-    def prnt():
+    def prnt(param, other):
         """first parent's line
 
         Attributes
@@ -461,7 +465,7 @@ def test_numpy_with_merge():
 
         Parameters
         ----------
-        Parent's param
+        params: Parent's param
 
         Extended Summary
         ----------------
@@ -488,7 +492,7 @@ def test_numpy_with_merge():
         ref"""
         pass
 
-    def child():
+    def child(params):
         """first child's line
 
         Deprecation Warning
@@ -497,7 +501,7 @@ def test_numpy_with_merge():
 
         Parameters
         ----------
-        child's params
+        params: child's params
 
         Yields
         ------
@@ -520,23 +524,23 @@ def test_numpy_with_merge():
     numpy_out = (
         "first child's line\n\nDeprecation Warning\n-------------------\ndep\n\nAttributes\n----------"
         "\nparent's params\n    indented\n\nmulti-line\n\nExtended Summary\n----------------\nextended\n"
-        "\nParameters\n----------\nParent's param\nchild's params\n\nReturns\n-------\nreturn\n\nYields"
-        "\n------\nyield\n\nOther Parameters\n----------------\nother\n\nRaises\n------\nraise\n\nSee Also"
+        "\nParameters\n----------\nparams: child's params\n\nReturns\n-------\nreturn\n\nYields"
+        "\n------\nyield\n\nRaises\n------\nraise\n\nSee Also"
         "\n--------\nsee\n\nNotes\n-----\nnote\n\nReferences\n----------\nref\n\nExamples\n--------\n"
         "child's example"
     )
     assert custom_inherit.store["numpy_with_merge"](None, None) is None
-    assert custom_inherit.store["numpy_with_merge"]("", "") is None
+    assert custom_inherit.store["numpy_with_merge"]("", new_func_with_doc("")) is None
     assert custom_inherit.store["numpy_with_merge"]("valid", None) == "valid"
-    assert custom_inherit.store["numpy_with_merge"](None, "valid") == "valid"
+    assert custom_inherit.store["numpy_with_merge"](None, new_func_with_doc("valid")) == "valid"
     assert (
-        custom_inherit.store["numpy_with_merge"](prnt.__doc__, child.__doc__)
+        custom_inherit.store["numpy_with_merge"](prnt.__doc__, child)
         == numpy_out
     )
 
 
 def test_numpy_napoleon_with_merge():
-    def prnt():
+    def prnt(params, other):
         """Parent's short summary
 
         Parent's extended summary
@@ -559,7 +563,7 @@ def test_numpy_napoleon_with_merge():
 
         Parameters
         ---------
-        parent's Parameters
+        params: parent's Parameters
 
         Returns
         -------
@@ -590,14 +594,14 @@ def test_numpy_napoleon_with_merge():
         alias of Yields - parent's"""
         pass
 
-    def child():
+    def child(params):
         """Child's short summary
 
         Child's extended summary
 
         Args
         ----
-        alias for Parameters - child's section
+        params: alias for Parameters - child's section
 
         Keyword Args
         ------------
@@ -632,18 +636,18 @@ def test_numpy_napoleon_with_merge():
     out = (
         "Child's short summary\n\nChild's extended summary\n\nAttributes\n----------\nparams\n    "
         "indented\n\nmulti-line\n\nMethods\n-------\nparent methods\n\nWarning\n-------\nwarnings\n"
-        "\nParameters\n----------\nparent's Parameters\nalias for Parameters - child's section\n"
-        "\nOther Parameters\n----------------\nother\n\nKeyword Arguments\n-----------------\n"
+        "\nParameters\n----------\nparams: alias for Parameters - child's section"
+        "\n\nKeyword Arguments\n-----------------\n"
         "parent's section\nalias for Keyword Arguments - child's section\n\nReturns\n-------\n"
         "return\n\nYields\n------\nyield\n\nRaises\n------\nraise\n"
         "\nNotes\n-----\nnote\n\nWarns\n-----\nwarns\n\nSee Also\n--------\nsee\n\nReferences\n"
         "----------\nref\n\nTodo\n----\ntodo\n\nExamples\n--------\nchild's example"
     )
     assert custom_inherit.store["numpy_napoleon_with_merge"](None, None) is None
-    assert custom_inherit.store["numpy_napoleon_with_merge"]("", "") is None
+    assert custom_inherit.store["numpy_napoleon_with_merge"]("", new_func_with_doc("")) is None
     assert custom_inherit.store["numpy_napoleon_with_merge"]("valid", None) == "valid"
-    assert custom_inherit.store["numpy_napoleon_with_merge"](None, "valid") == "valid"
+    assert custom_inherit.store["numpy_napoleon_with_merge"](None, new_func_with_doc("valid")) == "valid"
     assert (
-        custom_inherit.store["numpy_napoleon_with_merge"](prnt.__doc__, child.__doc__)
+        custom_inherit.store["numpy_napoleon_with_merge"](prnt.__doc__, child)
         == out
     )

--- a/tests/inheritance_test.py
+++ b/tests/inheritance_test.py
@@ -102,7 +102,7 @@ def test_inheritance_google_with_merge_style():
     class A(object):
         """Testing A.
 
-        Args:
+        Attributes:
             a :
                 parameter a.
             b :
@@ -122,7 +122,7 @@ def test_inheritance_google_with_merge_style():
     class B(A):
         """Testing B.
 
-        Parameters:
+        Attributes:
             d :
                 parameter d.
             e :
@@ -139,7 +139,7 @@ def test_inheritance_google_with_merge_style():
     class C(B):
         """Testing C.
 
-        Args:
+        Attributes:
             a :
                 priority description
                 of a
@@ -159,7 +159,7 @@ def test_inheritance_google_with_merge_style():
     """
     Testing C.
     
-    Parameters:
+    Attributes:
         a :
             priority description
             of a
@@ -188,5 +188,5 @@ def test_inheritance_google_with_merge_style():
 
     assert (
         C.__doc__
-        == "Testing C.\n\nParameters:\n    a :\n        priority description\n        of a\n    b :\n        parameter b.\n    c :\n        parameter c.\n    d :\n        parameter d.\n    e :\n        parameter e.\n    f :\n        parameter f.\n    g :\n        parameter g.\n    h :\n        parameter h.\n    i :\n        parameter i.\n\nReturns:\n    None\n\nNotes:\n    None"
+        == "Testing C.\n\nAttributes:\n    a :\n        priority description\n        of a\n    b :\n        parameter b.\n    c :\n        parameter c.\n    d :\n        parameter d.\n    e :\n        parameter e.\n    f :\n        parameter f.\n    g :\n        parameter g.\n    h :\n        parameter h.\n    i :\n        parameter i.\n\nReturns:\n    None\n\nNotes:\n    None"
     )

--- a/tests/metaclass_test.py
+++ b/tests/metaclass_test.py
@@ -270,20 +270,20 @@ def test_class_docstring_merge_hierarchy_google():
     class GrandParent(object):
         """GrandParent.
 
-        Args:
+        Attributes:
             foo
         """
 
     class Parent(GrandParent):
         """
-        Args:
+        Attributes:
             bar
         """
 
     class Child(Parent):
         pass
 
-    assert getdoc(Child) == "GrandParent.\n\nParameters:\n    foo\n    bar"
+    assert getdoc(Child) == "GrandParent.\n\nAttributes:\n    foo\n    bar"
 
 
 """ Include special method option"""

--- a/tests/store_test.py
+++ b/tests/store_test.py
@@ -22,7 +22,7 @@ def bad_style_type2(x, y):
 
 
 def good_style1(x, y):
-    return ",".join((x, y))
+    return None
 
 
 def good_style2(x, y):


### PR DESCRIPTION
In the following simplified situation:
```python
 def parent(foo):
     """
     Args:
         foo: Foo
     """

@doc_inherit(parent, style="google_with_merge")
 def child(x):
     """
     Args:
         x: X
     """
```

The inherited `child` doc is
```python
     """
     Args:
         foo: Foo
         x: X
     """
```
instead of
```python
     """
     Args:
         x: X
     """
```

This PR fixes this by removing the inherited args that are not in the signature. Any empty `Args` section (or any other signature related section names) is removed.
