### PR TITLE
Fix var args and kwargs positions

### DIFF
--- a/src/custom_inherit/_doc_parse_tools/section_items.py
+++ b/src/custom_inherit/_doc_parse_tools/section_items.py
@@ -98,6 +98,13 @@ def merge(prnt_sec, child_sec, merge_within_sections, style):
     if merge_within_sections:
         body = prnt_sec.copy()
         body.update(child_sec)
+
+        # Move the var_args and var_kwargs to the end.
+        for star in ("*", "**"):
+            for key in body.copy():
+                if key.startswith(star):
+                    body[key] = body.pop(key)
+
         body = _render(body, style)
     else:
         body = prnt_sec if not child_sec else child_sec

--- a/tests/inheritance_test.py
+++ b/tests/inheritance_test.py
@@ -107,7 +107,7 @@ def test_inheritance_google_with_merge_style():
                 parameter a.
             b :
                 parameter b.
-            c :
+            **c :
                 parameter c.
 
         Returns:
@@ -127,7 +127,7 @@ def test_inheritance_google_with_merge_style():
                 parameter d.
             e :
                 parameter e.
-            f :
+            *f :
                 parameter f.
 
         Return:
@@ -156,37 +156,7 @@ def test_inheritance_google_with_merge_style():
 
         pass
 
-    """
-    Testing C.
-    
-    Parameters:
-        a :
-            priority description
-            of a
-        b :
-            parameter b.
-        c :
-            parameter c.
-        d :
-            parameter d.
-        e :
-            parameter e.
-        f :
-            parameter f.
-        g :
-            parameter g.
-        h :
-            parameter h.
-        i :
-            parameter i.
-    
-    Returns:
-        None
-    
-    Notes:
-        None"""
-
     assert (
         C.__doc__
-        == "Testing C.\n\nParameters:\n    a :\n        priority description\n        of a\n    b :\n        parameter b.\n    c :\n        parameter c.\n    d :\n        parameter d.\n    e :\n        parameter e.\n    f :\n        parameter f.\n    g :\n        parameter g.\n    h :\n        parameter h.\n    i :\n        parameter i.\n\nReturns:\n    None\n\nNotes:\n    None"
+        == "Testing C.\n\nParameters:\n    a :\n        priority description\n        of a\n    b :\n        parameter b.\n    d :\n        parameter d.\n    e :\n        parameter e.\n    g :\n        parameter g.\n    h :\n        parameter h.\n    i :\n        parameter i.\n    *f :\n        parameter f.\n    **c :\n        parameter c.\n\nReturns:\n    None\n\nNotes:\n    None"
     )


### PR DESCRIPTION
When merged, the var args and kwargs stay at the position they were in the parent signature and child parameters could appear after them, whereas they shall be at the end.

This PR move those parameters at the end of the parameters section.